### PR TITLE
Change label on Prompt component to placeholder

### DIFF
--- a/src/components/prompt/index.js
+++ b/src/components/prompt/index.js
@@ -8,7 +8,7 @@ export default function Prompt(props) {
     <div class={style.textInput}>
       <form onSubmit={props.onSubmit}>
           <Textfield
-            label="add an item..."
+            placeholder="add an item..."
             onChange={props.onChange}
             value={props.value}
             multiline={false}


### PR DESCRIPTION
Rather than using the label property on the Preact Material Textfield object, this uses the placeholder property of input.

This provides a workaround for issue #1 